### PR TITLE
setDisabledState interface to catch disabled event

### DIFF
--- a/src/ui-switch.component.ts
+++ b/src/ui-switch.component.ts
@@ -180,4 +180,8 @@ export class UiSwitchComponent implements ControlValueAccessor {
   registerOnTouched(fn: any) {
     this.onTouchedCallback = fn;
   }
+
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled
+  }
 }


### PR DESCRIPTION
It's a simple modification in order to catch the disabled state from the form control without setting the class on the component instance.