### PR TITLE
(feat): inline styling isn't used by default unless explicitly set in config - #188 and #287

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve --aot",
-    "build": "rimraf dist && ts-node build.ts",
+    "build": "rimraf dist && ts-node build.ts && ncp src/lib/ui-switch/ui-switch.component.scss dist/packages-dist/ui-switch.component.scss && node-sass src/lib/ui-switch/ui-switch.component.scss dist/packages-dist/ui-switch.component.css",
     "build:demo": "rimraf demo && ng build --aot --prod --base-href=/ngx-ui-switch/demo/ --output-path=demo",
     "release": "cd dist/packages-dist && yarn publish",
     "bundlesize": "bundlesize",
@@ -70,6 +70,8 @@
     "karma-coverage-istanbul-reporter": "^1.3.0",
     "karma-jasmine": "^1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
+    "ncp": "^2.0.0",
+    "node-sass": "^4.9.2",
     "protractor": "^5.1.2",
     "rimraf": "^2.6.2",
     "rollup": "^0.52.1",

--- a/src/lib/ui-switch/ui-switch.component.scss
+++ b/src/lib/ui-switch/ui-switch.component.scss
@@ -1,0 +1,72 @@
+.switch {
+    border: 1px solid #dfdfdf;
+    position: relative;
+    display: inline-block;
+    box-sizing: content-box;
+    overflow: visible;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    box-shadow: rgb(223, 223, 223) 0 0 0 0 inset;
+    transition: 0.3s ease-out all;
+    -webkit-transition: 0.3s ease-out all;
+
+    small {
+        border-radius: 100%;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+        position: absolute;
+        top: 0;
+        left: 0;
+        transition: 0.3s ease-out all;
+        -webkit-transition: 0.3s ease-out all;
+        background:#fff;
+    }
+
+    &.checked {
+        background: rgb(100, 189, 99);
+    }
+
+    &.disabled {
+        opacity: .50;
+        cursor: not-allowed;
+    }
+
+    &.switch-small {
+        width: 33px;
+        height: 20px;
+        border-radius: 20px;
+        small {
+            width: 20px;
+            height: 20px;
+        }
+        &.checked small {
+            left: 13px;
+        }
+    }
+
+    &.switch-medium {
+        width: 50px;
+        height: 30px;
+        border-radius: 30px;
+        small {
+            width: 30px;
+            height: 30px;
+        }
+        &.checked small {
+            left: 20px;
+        }
+    }
+
+    &.switch-large {
+        width: 66px;
+        height: 40px;
+        border-radius: 40px;
+        small {
+            width: 40px;
+            height: 40px;
+        }
+        &.checked small {
+            left: 26px;
+        }
+    }
+}

--- a/src/lib/ui-switch/ui-switch.component.ts
+++ b/src/lib/ui-switch/ui-switch.component.ts
@@ -34,89 +34,6 @@ const UI_SWITCH_CONTROL_VALUE_ACCESSOR: any = {
     </small>
     </span>
   `,
-  styles: [
-    `
-    .switch {
-    background: #f00;
-    border: 1px solid #dfdfdf;
-    position: relative;
-    display: inline-block;
-    box-sizing: content-box;
-    overflow: visible;
-    padding: 0;
-    margin: 0;
-    cursor: pointer;
-    box-shadow: rgb(223, 223, 223) 0 0 0 0 inset;
-    transition: 0.3s ease-out all;
-    -webkit-transition: 0.3s ease-out all;
-    }
-
-    small {
-    border-radius: 100%;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
-    position: absolute;
-    top: 0;
-    left: 0;
-    transition: 0.3s ease-out all;
-    -webkit-transition: 0.3s ease-out all;
-    }
-
-    .switch-large {
-    width: 66px;
-    height: 40px;
-    border-radius: 40px;
-    }
-
-    .switch-large small {
-    width: 40px;
-    height: 40px;
-    }
-
-    .switch-medium {
-    width: 50px;
-    height: 30px;
-    border-radius: 30px;
-    }
-
-    .switch-medium small {
-    width: 30px;
-    height: 30px;
-    }
-
-    .switch-small {
-    width: 33px;
-    height: 20px;
-    border-radius: 20px;
-    }
-
-    .switch-small small {
-    width: 20px;
-    height: 20px;
-    }
-
-    .checked {
-    background: rgb(100, 189, 99);
-    border-color: rgb(100, 189, 99);
-    }
-
-    .switch-large.checked small {
-    left: 26px;
-    }
-
-    .switch-medium.checked small {
-    left: 20px;
-    }
-
-    .switch-small.checked small {
-    left: 13px;
-    }
-
-    .disabled {
-    opacity: .50;
-    cursor: not-allowed;
-    }
-    `,
-  ],
   providers: [UI_SWITCH_CONTROL_VALUE_ACCESSOR],
 })
 export class UiSwitchComponent implements ControlValueAccessor {
@@ -178,11 +95,11 @@ export class UiSwitchComponent implements ControlValueAccessor {
     private cdr: ChangeDetectorRef
   ) {
     this.size = config && config.size || 'medium';
-    this.color = config && config.color || 'rgb(100, 189, 99)';
-    this.switchOffColor = config && config.switchOffColor || '';
-    this.switchColor = config && config.switchColor || '#fff';
-    this.defaultBgColor = config && config.defaultBgColor || '#fff';
-    this.defaultBoColor = config && config.defaultBoColor || '#dfdfdf';
+    this.color = config && config.color;
+    this.switchOffColor = config && config.switchOffColor;
+    this.switchColor = config && config.switchColor;
+    this.defaultBgColor = config && config.defaultBgColor;
+    this.defaultBoColor = config && config.defaultBoColor;
   }
 
   getColor(flag = '') {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -32,6 +32,7 @@
 // @import "~bootstrap/scss/popover";
 // @import "~bootstrap/scss/carousel";
 @import '~bootstrap/scss/utilities';
+@import 'lib/ui-switch/ui-switch.component';
 
 body {
   background-color: #fcfcfc;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4805,6 +4805,10 @@ ncname@1.0.x:
   dependencies:
     xml-char-classes "^1.0.0"
 
+ncp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+
 needle@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.1.tgz#b5e325bd3aae8c2678902fa296f729455d1d3a7d"
@@ -4938,6 +4942,30 @@ node-sass@^4.9.0:
     node-gyp "^3.3.1"
     npmlog "^4.0.0"
     request "~2.79.0"
+    sass-graph "^2.2.4"
+    stdout-stream "^1.4.0"
+    "true-case-path" "^1.0.2"
+
+node-sass@^4.9.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.9.2.tgz#5e63fe6bd0f2ae3ac9d6c14ede8620e2b8bdb437"
+  dependencies:
+    async-foreach "^0.1.3"
+    chalk "^1.1.1"
+    cross-spawn "^3.0.0"
+    gaze "^1.0.0"
+    get-stdin "^4.0.1"
+    glob "^7.0.3"
+    in-publish "^2.0.0"
+    lodash.assign "^4.2.0"
+    lodash.clonedeep "^4.3.2"
+    lodash.mergewith "^4.6.0"
+    meow "^3.7.0"
+    mkdirp "^0.5.1"
+    nan "^2.10.0"
+    node-gyp "^3.3.1"
+    npmlog "^4.0.0"
+    request "2.87.0"
     sass-graph "^2.2.4"
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
@@ -6150,7 +6178,7 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.0.0, request@^2.72.0, request@^2.74.0, request@^2.78.0, request@^2.83.0:
+request@2.87.0, request@^2.0.0, request@^2.72.0, request@^2.74.0, request@^2.78.0, request@^2.83.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:


### PR DESCRIPTION
Solves #188 and #287.

Brief summary:
1. Styles were moved to separate `ui-switch.component.scss` file.
2. That new `.scss` file is imported into `styles.scss` for demo purposes.
3. Two new dev dependencies were added: `ncp` - for copying files, `node-sass` - for CSS compilation.
4. During `yarn build` after `ts-node` job `ncp` copies `ui-switch.component.scss` into dist package directory and then `node-sass` adds copiled css there.
5. Users may add the `.scss` to their project via simple import (we'll need to update docs as well):
```scss
//...
@import '~ui-switch/ui-switch.component';
//...
```
6. In `src/lib/ui-switch/ui-switch.component.ts` the fallback values for `color`,  `switchOffColor`, `switchColor`, `defaultBgColor` and `defaultBoColor` were removed. So if they were set by user (in config or template) they'll still be applied, while if not - returning `undefined` for these properties allows inline CSS to NOT be added.

@webcat12345 what do you think? Main concerns here are: 
1. Backwards compatibility
2. Additional (though dev) dependencies.