### PR TITLE
Added optional text labels support (solves #247)

### DIFF
--- a/src/app/demo/demo.component.html
+++ b/src/app/demo/demo.component.html
@@ -54,6 +54,33 @@
       <ui-switch switchColor="red"></ui-switch>
       <ui-switch switchColor="blue"></ui-switch>
     </p>
+
+    <!-- Please uncomment the following to check the labels
+    <h3>with labels</h3>
+    <p>
+      <ui-switch uncheckedLabel="off" checkedLabel="on" size="small"></ui-switch>
+      <ui-switch uncheckedLabel="off" checkedLabel="on"></ui-switch>
+      <ui-switch uncheckedLabel="off" checkedLabel="on" size="large"></ui-switch>
+    </p>
+
+    <p>
+      <ui-switch checkedLabel="on" size="small"></ui-switch>
+      <ui-switch checkedLabel="on"></ui-switch>
+      <ui-switch checkedLabel="on" size="large"></ui-switch>
+    </p>
+
+    <p>
+      <ui-switch uncheckedLabel="off" size="small"></ui-switch>
+      <ui-switch uncheckedLabel="off" ></ui-switch>
+      <ui-switch uncheckedLabel="off" size="large"></ui-switch>
+    </p>
+
+    <p>
+      <ui-switch checkedLabel="SUPERDUPERLONGLABEL" uncheckedLabel="SUPERDUPERLONGLABEL" size="small"></ui-switch>
+      <ui-switch checkedLabel="SUPERDUPERLONGLABEL" uncheckedLabel="SUPERDUPERLONGLABEL"></ui-switch>
+      <ui-switch checkedLabel="SUPERDUPERLONGLABEL" uncheckedLabel="SUPERDUPERLONGLABEL" size="large"></ui-switch>
+    </p>
+    -->
   </div>
 
   <div class="col-lg-5 col-sm-6 border-left pl-5">

--- a/src/lib/ui-switch/ui-switch.component.scss
+++ b/src/lib/ui-switch/ui-switch.component.scss
@@ -1,29 +1,116 @@
+$sw-sm-knob-size : 20px !default;
+$sw-md-knob-size : 30px !default;
+$sw-lg-knob-size : 40px !default;
+
+$sw-sm-font-size : 9px !default;
+$sw-md-font-size : 16px !default;
+$sw-lg-font-size : 16px !default;
+
+$sw-sm-min-width : 33px;
+$sw-md-min-width : 50px;
+$sw-lg-min-width : 60px;
+
+%small-switch-min-width {
+    min-width: $sw-sm-min-width;
+}
+%medium-switch-min-width {
+    min-width: $sw-md-min-width;
+}
+%large-switch-min-width {
+    min-width: $sw-lg-min-width;
+}
+
+%small-label-font-size {
+    font-size: $sw-sm-font-size;
+}
+%medium-label-font-size {
+    font-size: $sw-md-font-size;
+}
+%large-label-font-size {
+    font-size: $sw-lg-font-size;
+}
+
+@mixin config-switch-sizes($prefix, $sizes...) {
+    @each $i in $sizes {
+        &.#{$prefix}#{nth($i, 1)} {
+            // min-width via placeholder
+            @extend %#{ nth($i, 1) }-switch-min-width;
+            height:nth($i, 2);
+            border-radius: nth($i, 2);
+            small {
+                width : nth($i, 2);
+                height: nth($i, 2);
+                right : calc(100% - #{ nth($i, 2) });
+            }
+            > .switch-pane {
+                > span {
+                    // font-size via placeholder
+                    @extend %#{ nth($i, 1) }-label-font-size;
+                    line-height: nth($i, 2);
+                }
+                .switch-label {
+                    &-checked {
+                        padding-right : nth($i, 2) + 5px;
+                        padding-left : (nth($i, 2) / 3 ) * 1.5;
+                    }
+                    &-unchecked {
+                        padding-left : nth($i, 2) + 5px;
+                        padding-right : (nth($i, 2) / 3 ) * 1.5;
+                    }
+                }
+            }
+        }
+    }
+}
+
 .switch {
     border: 1px solid #dfdfdf;
     position: relative;
     display: inline-block;
     box-sizing: content-box;
-    overflow: visible;
     padding: 0;
     margin: 0;
     cursor: pointer;
     box-shadow: rgb(223, 223, 223) 0 0 0 0 inset;
     transition: 0.3s ease-out all;
     -webkit-transition: 0.3s ease-out all;
+    white-space: nowrap;
 
     small {
         border-radius: 100%;
         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
         position: absolute;
         top: 0;
-        left: 0;
+        right: calc(100% - 30px);
         transition: 0.3s ease-out all;
         -webkit-transition: 0.3s ease-out all;
         background:#fff;
     }
 
+    // populate &.small, &.medium, &.large classes
+    @include config-switch-sizes('switch-',
+        'small'   $sw-sm-knob-size,
+        'medium'  $sw-md-knob-size,
+        'large'   $sw-lg-knob-size
+    );
+
     &.checked {
         background: rgb(100, 189, 99);
+        &.checked small {
+            right: 0;
+            left: auto;
+        }
+        .switch-pane {
+            top:0;
+            .switch-label {
+                &-checked {
+                    opacity:1;
+                }
+                &-unchecked {
+                    opacity:0;
+                }
+            }
+        }
     }
 
     &.disabled {
@@ -31,42 +118,28 @@
         cursor: not-allowed;
     }
 
-    &.switch-small {
-        width: 33px;
-        height: 20px;
-        border-radius: 20px;
-        small {
-            width: 20px;
-            height: 20px;
+    .switch-pane {
+        display:flex;
+        flex-direction: column;
+        height:100%;
+        min-height:100%;
+        justify-content: flex-start;
+        align-items: center;
+        top:-100%;
+        position:relative;
+        pointer-events: none;
+        > span {
+            display:block;
+            min-height:100%;
         }
-        &.checked small {
-            left: 13px;
-        }
-    }
 
-    &.switch-medium {
-        width: 50px;
-        height: 30px;
-        border-radius: 30px;
-        small {
-            width: 30px;
-            height: 30px;
-        }
-        &.checked small {
-            left: 20px;
-        }
-    }
-
-    &.switch-large {
-        width: 66px;
-        height: 40px;
-        border-radius: 40px;
-        small {
-            width: 40px;
-            height: 40px;
-        }
-        &.checked small {
-            left: 26px;
+        .switch-label {
+            &-checked {
+                opacity:0;
+            }
+            &-unchecked {
+                opacity:1;
+            }
         }
     }
 }

--- a/src/lib/ui-switch/ui-switch.component.ts
+++ b/src/lib/ui-switch/ui-switch.component.ts
@@ -30,6 +30,10 @@ const UI_SWITCH_CONTROL_VALUE_ACCESSOR: any = {
     [style.background-color]="getColor()"
     [style.border-color]="getColor('borderColor')"
     >
+    <span class="switch-pane" *ngIf="checkedLabel || uncheckedLabel">
+        <span class="switch-label-checked">{{ this.checkedLabel }}</span>
+        <span class="switch-label-unchecked">{{ this.uncheckedLabel }}</span>
+    </span>
     <small [style.background]="getColor('switchColor')">
     </small>
     </span>
@@ -47,6 +51,8 @@ export class UiSwitchComponent implements ControlValueAccessor {
   @Input() switchColor;
   @Input() defaultBgColor;
   @Input() defaultBoColor;
+  @Input() checkedLabel;
+  @Input() uncheckedLabel;
 
   @Input()
   set checked(v: boolean) {

--- a/src/lib/ui-switch/ui-switch.config.ts
+++ b/src/lib/ui-switch/ui-switch.config.ts
@@ -1,4 +1,3 @@
-
 export interface UiSwitchModuleConfig {
   size?: string;
   color?: string;
@@ -6,4 +5,6 @@ export interface UiSwitchModuleConfig {
   switchColor?: string;
   defaultBgColor?: string;
   defaultBoColor?: string;
+  checkedLabel?: string;
+  uncheckedLabel?: string;
 }


### PR DESCRIPTION
@cmckni3 can you please check this one?

Adding labels is possible now via `checkedLabel` and `uncheckedLabel` optional settings. I tried to make the changes as universal as possible, so:

1. The labels are supported in all currently available sizes
2. The labels can be literally of any length 
3. Adding **only one** label (either `checkedLabel` or `uncheckedLabel`) is allowed as well. 

The trick in showing labels is in flex box parent `.switch-pane` which places labels one below another and changes its position going up or down to show the label currently needed. 

Please let me know what you think and if you have questions and/or ideas for improvements.