### PR TITLE
Add two properties to set the text color of the labels (Issue #315)

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,9 +300,63 @@ Note that if you are using the switch in a child `NgModule`, such as a lazy load
 
 > default: null
 
-
 ```html
 <ui-switch uncheckedLabel="off"></ui-switch>
+```
+
+### checkedTextColor
+
+*checked text color of the label*
+
+> type: *string*
+
+> default: black
+
+```html
+<ui-switch checkedTextColor="#7CFC00"></ui-switch>
+```
+
+### uncheckedTextColor
+
+*Unchecked text color of the label*
+
+> type: *string*
+
+> default: black
+
+```html
+<ui-switch uncheckedTextColor="red"></ui-switch>
+```
+
+## Switch Content
+```html
+<ui-switch uncheckedLabel="off">
+  <img src=""/>
+</ui-switch>
+```
+
+### checkedTextColor
+
+*checked text color of the label (on)*
+
+> type: *string*
+
+> default: black
+
+```html
+<ui-switch uncheckedTextColor="#7CFC00"></ui-switch>
+```
+
+### uncheckedTextColor
+
+*Unchecked text color of the label (off)*
+
+> type: *string*
+
+> default: black
+
+```html
+<ui-switch uncheckedTextColor="red"></ui-switch>
 ```
 
 ## Switch Content

--- a/src/app/demo/demo.component.html
+++ b/src/app/demo/demo.component.html
@@ -53,6 +53,11 @@
       <ui-switch switchColor="red"></ui-switch>
       <ui-switch switchColor="blue"></ui-switch>
     </p>
+
+    <h4>textColor</h4>
+    <p>
+      <ui-switch uncheckedTextColor="red" checkedTextColor="blue" checkedLabel="ON" uncheckedLabel="OFF"></ui-switch>
+    </p>
   </div>
 
   <div class="col-lg-5 col-sm-6 border-left pl-5">
@@ -104,6 +109,13 @@
           <ui-switch checkedLabel="SUPERDUPERLONGLABEL"
                      uncheckedLabel="SUPERDUPERLONGLABEL"
                      size="large"></ui-switch>
+        </p>
+        <p>
+          <ui-switch reverse
+                     uncheckedLabel="off"
+                     checkedLabel="on"
+                     uncheckedTextColor="orange"
+                     checkedTextColor="red"></ui-switch>
         </p>
       </div>
     </div>

--- a/src/lib/ui-switch/ui-switch.component.scss
+++ b/src/lib/ui-switch/ui-switch.component.scss
@@ -137,6 +137,8 @@ $sw-lg-min-width: 60px;
     }
 
     .switch-label {
+      color: black;
+      
       &-checked {
         opacity: 0;
       }

--- a/src/lib/ui-switch/ui-switch.component.ts
+++ b/src/lib/ui-switch/ui-switch.component.ts
@@ -30,11 +30,13 @@ const UI_SWITCH_CONTROL_VALUE_ACCESSOR: any = {
     [class.switch-medium]="size === 'medium'"
     [class.switch-small]="size === 'small'"
     [style.background-color]="getColor()"
-    [style.border-color]="getColor('borderColor')"
+    [style.border-color]="getColor('checkedBorderColor')"
     >
     <span class="switch-pane" *ngIf="checkedLabel || uncheckedLabel">
-      <span class="switch-label-checked">{{ this.checkedLabel }}</span>
-      <span class="switch-label-unchecked">{{ this.uncheckedLabel }}</span>
+      <span class="switch-label-checked"
+      [style.color]="getColor('checkedTextColor')">{{ this.checkedLabel }}</span>
+      <span class="switch-label-unchecked"
+      [style.color]="getColor('uncheckedTextColor')">{{ this.uncheckedLabel }}</span>
     </span>
     <small [style.background]="getColor('switchColor')">
       <ng-content></ng-content>
@@ -58,6 +60,8 @@ export class UiSwitchComponent implements ControlValueAccessor, OnDestroy {
   @Input() defaultBoColor;
   @Input() checkedLabel;
   @Input() uncheckedLabel;
+  @Input() checkedTextColor;
+  @Input() uncheckedTextColor;
   @Input() beforeChange: Observable<boolean>;
 
   @Input()
@@ -123,6 +127,8 @@ export class UiSwitchComponent implements ControlValueAccessor, OnDestroy {
     this.defaultBoColor = config && config.defaultBoColor;
     this.checkedLabel = config && config.checkedLabel;
     this.uncheckedLabel = config && config.uncheckedLabel;
+    this.checkedTextColor = config && config.checkedTextColor;
+    this.uncheckedTextColor = config && config.uncheckedTextColor;
   }
 
   getColor(flag = '') {
@@ -134,6 +140,12 @@ export class UiSwitchComponent implements ControlValueAccessor, OnDestroy {
         return !this.checked ? this.switchColor : this.switchOffColor || this.switchColor;
       }
       return this.checked ? this.switchColor : this.switchOffColor || this.switchColor;
+    }
+    if (flag === 'checkedTextColor') {
+      return this.reverse ? this.uncheckedTextColor : this.checkedTextColor;
+    }
+    if (flag === 'uncheckedTextColor') {
+      return this.reverse ? this.checkedTextColor : this.uncheckedTextColor;
     }
     if (this.reverse) {
       return !this.checked ? this.color : this.defaultBgColor;

--- a/src/lib/ui-switch/ui-switch.component.ts
+++ b/src/lib/ui-switch/ui-switch.component.ts
@@ -30,7 +30,7 @@ const UI_SWITCH_CONTROL_VALUE_ACCESSOR: any = {
     [class.switch-medium]="size === 'medium'"
     [class.switch-small]="size === 'small'"
     [style.background-color]="getColor()"
-    [style.border-color]="getColor('checkedBorderColor')"
+    [style.border-color]="getColor('borderColor')"
     >
     <span class="switch-pane" *ngIf="checkedLabel || uncheckedLabel">
       <span class="switch-label-checked"

--- a/src/lib/ui-switch/ui-switch.config.ts
+++ b/src/lib/ui-switch/ui-switch.config.ts
@@ -7,4 +7,6 @@ export interface UiSwitchModuleConfig {
   defaultBoColor?: string;
   checkedLabel?: string;
   uncheckedLabel?: string;
+  checkedTextColor?: string;
+  uncheckedTextColor?: string;
 }


### PR DESCRIPTION
This PR will add two properties to the component : `checkedTextColor` and `uncheckedTextColor` that change the text colors of the `checkedLabel`/`uncheckedLabel`. This PR also includes the demo and the usage (in the README.md) for these properties.
The default value remains `black` for both labels.

This would close the issue #315.