### PR TITLE
Added the disabled state to the disabled attribute on the native html button

### DIFF
--- a/src/lib/ui-switch/ui-switch.component.html
+++ b/src/lib/ui-switch/ui-switch.component.html
@@ -2,6 +2,7 @@
   type="button"
   class="switch"
   role="switch"
+  [disabled]="disabled"
   [attr.aria-checked]="checked"
   [attr.aria-label]="ariaLabel"
   [class.checked]="checked"


### PR DESCRIPTION
I added the disabled toggle state to the disabled attribute on the native html button. This should help users who use the "onClick" event by not allowing that to trigger when the toggle is set to disabled. 