### PR TITLE
fix(ng-form): Remove manual onchange cb call

### DIFF
--- a/src/lib/ui-switch/ui-switch.component.ts
+++ b/src/lib/ui-switch/ui-switch.component.ts
@@ -180,7 +180,6 @@ export class UiSwitchComponent implements ControlValueAccessor, OnDestroy {
       this.checked = !!obj;
     }
 
-    this.onChangeCallback(this.checked);
     // Added as part of #243 when change detection OnPush is set for the
     // hosting component
     // https://github.com/webcat12345/ngx-ui-switch/issues/243


### PR DESCRIPTION
Revert "fix(ng-form): Fix ng form init bug"

This reverts commit 1382bb140422c5efca4df9d6e15030da3535c2e2.

- Not sure why the change was made
- The change does not make sense due to how Angular forms operate

References #493