### PR TITLE
Remove @angular/animations dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "validate:renovate": "npx --yes --package renovate -- renovate-config-validator --strict"
   },
   "dependencies": {
-    "@angular/animations": "^17.0.0",
     "@angular/common": "^17.0.0",
     "@angular/compiler": "^17.0.0",
     "@angular/core": "^17.0.0",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { UiSwitchModule } from '../lib/public_api';
 
@@ -14,7 +13,7 @@ import { GithubLinkComponent } from './github-link/github-link.component';
 describe('AppComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [BrowserAnimationsModule, FormsModule, ReactiveFormsModule, UiSwitchModule],
+      imports: [FormsModule, ReactiveFormsModule, UiSwitchModule],
       declarations: [
         AppComponent,
         DemoComponent,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { UiSwitchModule } from '../lib/public_api';
 
@@ -20,7 +19,7 @@ import { GithubLinkComponent } from './github-link/github-link.component';
     HeaderComponent,
     GithubLinkComponent,
   ],
-  imports: [BrowserModule, BrowserAnimationsModule, UiSwitchModule],
+  imports: [BrowserModule, UiSwitchModule],
   providers: [],
   bootstrap: [AppComponent],
 })

--- a/src/lib/package.json
+++ b/src/lib/package.json
@@ -18,7 +18,6 @@
   ],
   "peerDependencies": {
     "@angular/core": ">=10.0.0",
-    "@angular/animations": ">=10.0.0",
     "@angular/common": ">=10.0.0",
     "@angular/forms": ">=10.0.0",
     "@angular/platform-browser": ">=10.0.0"

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -22,13 +22,6 @@
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
 /**
- * Web Animations `@angular/platform-browser/animations`
- * Only required if AnimationBuilder is used within the application and using IE/Edge or Safari.
- * Standard animation support in Angular DOES NOT require any polyfills (as of Angular 6.0).
- */
-// import 'web-animations-js';  // Run `npm install --save web-animations-js`.
-
-/**
  * By default, zone.js will patch all possible macroTask and DomEvents
  * user can disable parts of macroTask/DomEvents patch by setting following flags
  * because those flags need to be set before `zone.js` being loaded, and webpack

--- a/yarn.lock
+++ b/yarn.lock
@@ -198,13 +198,6 @@
     "@angular-eslint/bundled-angular-compiler" "17.5.3"
     "@typescript-eslint/utils" "7.11.0"
 
-"@angular/animations@^17.0.0":
-  version "17.3.12"
-  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-17.3.12.tgz#561aa502c309034c6d19cbbfc3dafddb0422d301"
-  integrity sha512-9hsdWF4gRRcVJtPcCcYLaX1CIyM9wUu6r+xRl6zU5hq8qhl35hig6ounz7CXFAzLf0WDBdM16bPHouVGaG76lg==
-  dependencies:
-    tslib "^2.3.0"
-
 "@angular/cli@^17.0.0":
   version "17.3.17"
   resolved "https://registry.yarnpkg.com/@angular/cli/-/cli-17.3.17.tgz#15464e29db9a806b52d7574f46d1deb705838fbd"


### PR DESCRIPTION
The library and demo app don't use any @angular/animations triggers or the AnimationBuilder, so BrowserAnimationsModule was unnecessary. Per the Angular migration guide (angular.dev/guide/animations/migration), drop the package entirely along with its now-unused wiring.